### PR TITLE
Update dark mode styles for search input

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,7 +4,14 @@
 
 @layer base {
   input[type='search'] {
-    @apply block w-full rounded px-4 py-3 border-gray-200 focus:border-gray-300 focus:ring-1 focus:ring-gray-300 appearance-none
+    @apply appearance-none;
+    @apply block w-full rounded px-4 py-3;
+    @apply mersocarlin-bg-white mersocarlin-text-gray;
+    @apply focus:ring-1;
+    @apply focus:ring-gray-300;
+    @apply dark:focus:ring-gray-400;
+    @apply border-gray-200 focus:border-gray-300;
+    @apply dark:border-gray-500 dark:focus:border-gray-400;
   }
 }
 


### PR DESCRIPTION
My site has high traffic amongst "dark mode" users and the search input from the blog post page was a bit "too bright" :)

|Before|After|
|--|--|
|<img width="796" alt="before" src="https://user-images.githubusercontent.com/3759165/112748748-d1676980-8fb5-11eb-8aac-edf58d2acdb3.png">|<img width="795" alt="after" src="https://user-images.githubusercontent.com/3759165/112748749-d1676980-8fb5-11eb-9ce4-f5eeee477dc4.png">|


